### PR TITLE
add list of timers to captures

### DIFF
--- a/lib/app_api/captures.ex
+++ b/lib/app_api/captures.ex
@@ -7,7 +7,6 @@ defmodule AppApi.Captures do
   alias AppApi.Repo
 
   alias AppApi.Captures.Capture
-  alias AppApi.Timers.Timer
 
   @doc """
   Returns the list of captures.
@@ -43,7 +42,6 @@ defmodule AppApi.Captures do
       from c in Capture,
         where: c.id_person == ^id_person,
         preload: [:timers]
-
 
     Repo.all(query)
   end

--- a/lib/app_api/captures.ex
+++ b/lib/app_api/captures.ex
@@ -7,6 +7,7 @@ defmodule AppApi.Captures do
   alias AppApi.Repo
 
   alias AppApi.Captures.Capture
+  alias AppApi.Timers.Timer
 
   @doc """
   Returns the list of captures.
@@ -38,7 +39,12 @@ defmodule AppApi.Captures do
   def get_capture!(id), do: Repo.get!(Capture, id)
 
   def get_capture_by_id_person(id_person) do
-    query = from c in Capture, where: c.id_person == ^id_person
+    query =
+      from c in Capture,
+        where: c.id_person == ^id_person,
+        preload: [:timers]
+
+
     Repo.all(query)
   end
 

--- a/lib/app_api_web/controllers/capture_controller.ex
+++ b/lib/app_api_web/controllers/capture_controller.ex
@@ -3,7 +3,6 @@ defmodule AppApiWeb.CaptureController do
 
   def index(conn, _params) do
     captures = AppApi.Captures.get_capture_by_id_person(conn.assigns.person.id_person)
-
     render(conn, "index.json", captures: captures)
   end
 

--- a/lib/app_api_web/views/capture_view.ex
+++ b/lib/app_api_web/views/capture_view.ex
@@ -1,5 +1,6 @@
 defmodule AppApiWeb.CaptureView do
   use AppApiWeb, :view
+  alias AppApiWeb.TimerView
 
   def render("index.json", %{captures: captures}) do
     %{data: Enum.map(captures, &capture_to_json/1)}
@@ -14,7 +15,8 @@ defmodule AppApiWeb.CaptureView do
       capture_id: capture.id,
       id_person: capture.id_person,
       text: capture.text,
-      completed: capture.completed
+      completed: capture.completed,
+      timers: Enum.map(capture.timers, &TimerView.timer_to_json/1)
     }
   end
 end


### PR DESCRIPTION
preload timers for each captures and return the list of timers in the response json when the GET endpoint `/api/captures` is requested