### PR TITLE
fix typo in avatar data

### DIFF
--- a/lib/app_api_web/auth_service_api.ex
+++ b/lib/app_api_web/auth_service_api.ex
@@ -31,7 +31,7 @@ defmodule AppApiWeb.AuthServiceApi do
           id_person: data["data"]["id_person"],
           name: "",
           email: data["data"]["email"],
-          avatar: ["data"]["avatar"]
+          avatar: data["data"]["avatar"]
         }
 
         {:ok, person}


### PR DESCRIPTION
fix typo when retrieving the avatar info from the auth service data